### PR TITLE
Rhiju/melt with linear baseline

### DIFF
--- a/do_new_likelihood_fit.m
+++ b/do_new_likelihood_fit.m
@@ -26,14 +26,14 @@ SIGMIN_FRAC = 0.1;
 for n = 1:numiter
 
   [pred_fit, C_state ] = do_linear_fit_vs_conc( data, f, lane_normalization, C_state_in, sigma_at_each_residue, beta_C );
-
+  
   sigma_at_each_residue = get_sigma_at_each_residue( data, pred_fit, lane_normalization, SIGMIN_FRAC );
-
+  
   if ( n < numiter )
     lane_normalization = normalize_lanes( data, pred_fit, sigma_at_each_residue );
   end
 
-  end
+end
 
 logL = - numconc * sum( log( sigma_at_each_residue ) );
 
@@ -95,7 +95,7 @@ else
   end
    
   C = A\B';
-   
+
   % to enforce that C is positive...
   %for m = 1:size( B, 1 );
   %  C(:,m) = lsqnonneg( A, B(m,:)' );

--- a/do_new_likelihood_fit_wrapper_for_fminbnd.m
+++ b/do_new_likelihood_fit_wrapper_for_fminbnd.m
@@ -1,5 +1,5 @@
 function [minus_logL, pred_fit, lane_normalization, sigma_at_each_residue] = ...
-    do_new_likelihood_fit_wrapper_for_fminbnd( p, input_data, conc, fit_type, lane_normalization_in, C_state_in, p2_best );
+    do_new_likelihood_fit_wrapper_for_fminbnd( p, input_data, conc, fit_type, lane_normalization_in, C_state_in, p2_best, min_frac_error );
 
 p1 = p(1); 
 if length( p ) > 1
@@ -7,5 +7,5 @@ if length( p ) > 1
 else
   p2 = p2_best;
 end
-[logL, pred_fit, lane_normalization, sigma_at_each_residue ] = do_new_likelihood_fit( input_data, conc, p1, p2, fit_type, lane_normalization_in, C_state_in );
+[logL, pred_fit, lane_normalization, sigma_at_each_residue ] = do_new_likelihood_fit( input_data, conc, p1, p2, fit_type, lane_normalization_in, C_state_in, [], min_frac_error );
 minus_logL = -logL;

--- a/lifft.m
+++ b/lifft.m
@@ -1,5 +1,5 @@
-function [ p1_best, p2_best, log_L, C_state, input_data_rescale, conc_fine, pred_fit_fine_rescale ] = lifft( input_data, conc, resnum, param1, param2, whichres, fit_type, C_state_in, plot_res, do_centralize, conc_fine )
-%  [ p1_best, p2_best, log_L, C_state, input_data_rescale, conc_fine, pred_fit_fine_rescale ] = lifft( input_data, conc, resnum, param1, param2, whichres, fit_type, C_state_in, plot_res, do_centralize, conc_fine );
+function [ p1_best, p2_best, log_L, C_state, input_data_rescale, conc_fine, pred_fit_fine_rescale, input_data_renorm, pred_fit_fine ] = lifft( input_data, conc, resnum, param1, param2, whichres, fit_type, C_state_in, plot_res, do_centralize, conc_fine, min_frac_error, do_lane_normalization )
+%  [ p1_best, p2_best, log_L, C_state, input_data_rescale, conc_fine, pred_fit_fine_rescale, input_data_renorm, pred_fit_fine  ] = lifft( input_data, conc, resnum, param1, param2, whichres, fit_type, C_state_in, plot_res, do_centralize, conc_fine, min_frac_error, do_lane_normalization );
 %
 % LIFFT: Likelihood-informed Fits of Footprinting Titraions
 %
@@ -7,19 +7,35 @@ function [ p1_best, p2_best, log_L, C_state, input_data_rescale, conc_fine, pred
 %  errors at each residue while doing a grid search over midpoints and apparent Hill coefficients.
 %
 %  Inputs:
+%
 %  input_data = matrix of input structure mapping data, approximately normalized (e.g., by mean intensity in each lane)
 %                 must have dimensions of (number of residues x number of lanes ).
-%  conc       = concentration of chemical in titration (e.g., [adenine], or [Mg2+] )
+%  conc       = concentration of chemical in titration (e.g., [adenine], or [Mg2+] ), or temperature (in C, for melts).
 %  resnum     = your favorite numbering of residues  (if you give empty set [], you'll get 1:number of columns in input_data )
-%  K1_conc    = concentrations to search over. (Default: 10.^[-3.0 : 0.1 :3.0]).
-%  param2     = apparent Hill coefficients to search over. (Default: param2 = [0.05:0.05:4] )
+%  param1     = parameter 1 values (e.g., concentrations) to search over. (Default: 10.^[-3.0 : 0.1 :3.0]).
+%  param2     = parameter 2 values (e.g., apparent Hill coefficients) to search over. (Default: param2 = [0.05:0.05:4] )
 %  whichres   = [optional!] just look at this subset of input residues. (Give empty set [] to look at all residues. )
-%  fit_type   = string specifying functional form to search: "hill", "double_exp", "one_two" ( default is "hill" )
+%  fit_type   = string specifying functional form to search: "hill", "double_exp", "one_two", "melt" ( default is "hill" )
+%
+%  Less commonly used inputs...
 %  C_state_in = a 'target' set of values for footprinting data for each state. If not specified or [], no target set.
 %  plot_res   = which residues, if any, to make a 'nice' Hill plot with.  
-%  do_centralize = pre-'normalize' the data based on assumption that some residues stay invariant during the titration (default = 1, i.e., true)
+%  do_centralize  = pre-'normalize' the data based on assumption that some residues stay invariant during the titration (default = 1, i.e., true)
+%  conc_fine      = finely spaced concentrations to use when plotting. If not specified or [], use default.
+%  min_frac_error = minimum assumed relative error in points (default is 0.1)
+%  do_lane_normalization = try to fit lane normalization for each parameter value. (default is 1)
 %
-% (C) Das lab, Stanford University, 2008-2014
+% Outputs:
+%  p1_best = best fit for parameter 1 (e.g., K_d).
+%  p2_best = best fit for parameter 2 (e.g., hill coefficient).
+%  log_L   = matrix of log-likelihood values over input param1, param2.
+%  input_data_rescale = input_data over plot_res, rescaled from 0 to 1 (as shows up in plot_res plot)
+%  conc_fine             = concentrations assumed in making a fine curve that goes through input_data_rescale
+%  pred_fit_fine_rescale = values from 0 to 1 in fine curve fit through input_data_rescale
+%  input_data_renorm     = all input_data, lane normalizations applied
+%  pred_fit_fine_renorm  = predicted data, lane normalizations applied
+%
+% (C) Das lab, Stanford University, 2008-2016
 % 
 
 % initialization stuff
@@ -31,11 +47,13 @@ if size( input_data, 2) ~= length( conc )  ;  fprintf( '\nNumber of input_data r
 if size( input_data, 1) ~= length( resnum );  fprintf( '\nNumber of input_data cols must equal number of values in resnum\n' ); return; end;
 if ~exist( 'do_centralize'); do_centralize = 1; end;
 if ( do_centralize); input_data = centralize( input_data ); end;
+if ~exist( 'do_lane_normalization' ); do_lane_normalization = 1; end;
+if ( do_lane_normalization ) lane_normalization_in = []; else; lane_normalization_in = ones(1,size(input_data,2));  end
 if ~exist( 'plot_res' ); plot_res = []; end;
-
 if ~exist( 'param1' ) | isempty( param1 ); param1 = 10.^[-3.0 : 0.1 :3.0]; end
 if ~exist( 'param2' ) | isempty( param2 ); param2 = [0.05:0.05:4]; end;
 if ~exist( 'resnum' ) | isempty( resnum ); resnum = [1:size( input_data, 1 ) ]; end;
+if ~exist( 'min_frac_error' ) | isempty( min_frac_error ); min_frac_error = 0.2; end;
 if exist( 'whichres' ) & ~isempty( whichres )
   for k = 1:length(whichres)
     res_to_fit(k) = find( resnum == whichres(k) );
@@ -69,12 +87,12 @@ for i = 1: length( param1)
   if exist( 'parfor' )
     parfor j = 1: length( param2) % this could be parallelized for speed..
       [ log_L(i,j), sigma_all(:,i,j) ] = run_inner_loop( param1( i ), param2( j ),...
-						  input_data, conc, fit_type, [], C_state_in );
+						  input_data, conc, fit_type, lane_normalization_in, C_state_in, min_frac_error );
     end
   else
     for j = 1: length( param2) % this could be parallelized for speed..
       [ log_L(i,j), sigma_all(:,i,j) ] = run_inner_loop( param1( i ), param2( j ),...
-						  input_data, conc, fit_type, [], C_state_in );
+						  input_data, conc, fit_type, lane_normalization_in, C_state_in, min_frac_error );
     end
   end
 end
@@ -97,10 +115,10 @@ if OPTIMIZE_MINIMUM
 % originally tried fminbound, but that doesn't work for 2D
 %p_fminbnd = fminbnd(  'do_new_likelihood_fit_wrapper_for_fminbnd', [param1(ind1-1) param2(ind2-1)], [param1(ind1+1),param2(ind2+1)], [], input_data, conc, fit_type, [], C_state_in );
   if length( param2 ) > 1
-    [p_fminbnd, minus_log_L_best] = fminsearch(  'do_new_likelihood_fit_wrapper_for_fminbnd', [p1_best, p2_best], [], input_data, conc, fit_type, [], C_state_in );
+    [p_fminbnd, minus_log_L_best] = fminsearch(  'do_new_likelihood_fit_wrapper_for_fminbnd', [p1_best, p2_best], [], input_data, conc, fit_type, lane_normalization_in, C_state_in, [], min_frac_error );
     p1_best = p_fminbnd(1); p2_best = p_fminbnd(2);
   else
-    [p_fminbnd, minus_log_L_best] = fminsearch(  'do_new_likelihood_fit_wrapper_for_fminbnd', [p1_best ], [], input_data, conc, fit_type, [], C_state_in, p2_best );
+    [p_fminbnd, minus_log_L_best] = fminsearch(  'do_new_likelihood_fit_wrapper_for_fminbnd', [p1_best ], [], input_data, conc, fit_type, lane_normalization_in, C_state_in, p2_best, min_frac_error );
     p1_best = p_fminbnd(1);
   end
 log_L_best = -minus_log_L_best;
@@ -109,7 +127,7 @@ end
 %fprintf(1,'%s %8.4f. %s %8.4f ==>  LogL %8.4f\n', p1_name, p1_best, p2_name, p2_best, log_L_best);
 
 [logLbest, pred_fit, lane_normalization, sigma_at_each_residue, C_state ] =...
-    do_new_likelihood_fit( input_data, conc, p1_best, p2_best, fit_type, [],  C_state_in );
+    do_new_likelihood_fit( input_data, conc, p1_best, p2_best, fit_type, lane_normalization_in, C_state_in, [], min_frac_error );
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -190,7 +208,10 @@ input_data_rescale = []; pred_fit_fine_rescale = [];
 
 if length( plot_res ) > 0; [input_data_rescale, pred_fit_fine_rescale] = make_plot_res_plot( C_state, input_data, lane_normalization, plot_res, conc, resnum, conc_fine, pred_fit_fine,  titlestring, fit_type ); end;
 
-
+% useful for plotting values at each data point, compared to fits.
+input_data_renorm = input_data * diag( 1./lane_normalization ); % apply lane normalization
+f = feval( fit_type, conc_fine, p1_best, p2_best); % fraction folded values
+pred_data_fine_renorm = C_state'*f;
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -253,10 +274,11 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 function [logL, sigma_vector] = run_inner_loop( p1, p2, ...
-						input_data, conc, fit_type, lane_normalization_in, C_state_in )
+						input_data, conc, fit_type, lane_normalization_in, ...
+						C_state_in, min_frac_error )
     
 [logL, pred_fit, lane_normalization, sigma_at_each_residue] = ...
-    do_new_likelihood_fit( input_data, conc, p1, p2, fit_type, lane_normalization_in, C_state_in );
+    do_new_likelihood_fit( input_data, conc, p1, p2, fit_type, lane_normalization_in, C_state_in, [], min_frac_error );
 
 sigma_vector = [sigma_at_each_residue' std( lane_normalization )];
 

--- a/make_logL_contour_plot.m
+++ b/make_logL_contour_plot.m
@@ -1,4 +1,5 @@
 function make_logL_contour_plot( logLout, param1, param2, param1_name, param2_name, p1_best, p2_best )
+% make_logL_contour_plot( logLout, param1, param2, param1_name, param2_name, p1_best, p2_best )
 
 if ~exist( 'param1_name' ); param1_name = 'K'; end;
 if ~exist( 'param2_name' ); param2_name = 'n_{Hill}'; end;

--- a/melt_with_linear_baseline.m
+++ b/melt_with_linear_baseline.m
@@ -1,0 +1,13 @@
+function [f, p1_name, p2_name, variable_parameter_name ] = melt_with_linear_baseline( temperatures, Tm, delH );
+p1_name = 'Tm';
+p2_name = 'delta-H';
+variable_parameter_name = 'temperature';
+R = 0.001986; % kcal/mol/K
+
+% convert celsius to K
+K = exp( (delH/R) * (1/(Tm+273.15) - 1./(temperatures + 273.15)));
+
+pred = 1.0 ./ (1.0 + K);
+f = [pred; 1.0-pred];
+
+f = [f; f.*repmat( temperatures, size(f,1), 1 )];

--- a/plot_titration_data.m
+++ b/plot_titration_data.m
@@ -64,7 +64,7 @@ for i = 1:numres
   h = text( conc(startpt), plot_offset*(i-1)+pred_fit(i,startpt), num2str( resnum( i ) ) );
   set(h,'color','k','fontsize',8,'fontweight','bold');
 end
-if (fit_type == 'melt' )
+if ~isempty( strfind( fit_type, 'melt' ) )
   set(gca,'xscale','lin');
 else
   set(gca,'xscale','log');
@@ -73,7 +73,7 @@ ylim2 = [0 (numres+1)*plot_offset+max(max(data))];
 if ( size( pred_fit, 1 )== 1  ) ylim2 = [min( data) max(data) ]; end;
 set(gca,'ylim',ylim2,'xlim',[ min(conc) max(conc) ])
 set(gca,'linew',2,'fontsize',14,'fontw','bold');
-if ( fit_type == 'melt' )
+if ~isempty( strfind( fit_type, 'melt' ) )
   xlabel('Temperature (C)');
 else
   xlabel('Conc. (mM)]');


### PR DESCRIPTION
Expanding LIFFT beyond chemical mapping!
Allow analysis of optical melt data where, e.g., multiple measurements are carried out in parallel in different cuvettes.
Uses the new 'melt_with_linear_baseline' function.